### PR TITLE
Add some guardrails to prevent segfaulting.

### DIFF
--- a/base/interval.h
+++ b/base/interval.h
@@ -48,6 +48,7 @@ struct IntervalSet {
   IntervalSet(std::initializer_list<base::Interval<T>> intervals) {
     for (const auto &interval : intervals) { insert(interval); }
   }
+  bool empty() const { return endpoints_.empty(); }
 
  private:
   using container_type = std::vector<T>;

--- a/diagnostic/console_renderer.cc
+++ b/diagnostic/console_renderer.cc
@@ -47,6 +47,10 @@ void ConsoleRenderer::Flush() {
 
 void ConsoleRenderer::WriteSourceQuote(frontend::Source const *source,
                                        SourceQuote const &quote) {
+  if (quote.lines.empty()) {
+    std::fputs("Internal Error: SourceQuote is empty\n", out_);
+    return;
+  }
   int border_alignment = NumDigits(quote.lines.endpoints_.back() - 1) + 2;
   for (base::Interval<frontend::LineNum> line_range : quote.lines) {
     for (frontend::LineNum line = line_range.begin(); line != line_range.end();

--- a/frontend/BUILD
+++ b/frontend/BUILD
@@ -29,6 +29,7 @@ cc_library(
         "//frontend/source:source",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
     ],
     test_deps = None,
 )


### PR DESCRIPTION
I was playing around with some bad inputs and managed to trigger a segfault with this improper struct declaration:

```
struct foo {
 x: int64
}
```

This confuses the parser, triggering an "unknown parse error" that contains zero lines of context, which leads to a hard crash when attempting to print the error message.

I don't know enough to actually fix this, so for now I've just added some extra guardrails to the error path.