### PR TITLE
Configure basic CI using Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup bazel
+        uses: abhinavsingh/setup-bazel@v3
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: "bazel build //..."
+      - name: Test
+        run: "bazel test //..."

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ fast to compile, fast to run, and easy to migrate.
 
 ## Building Icarus from Source
 
+![CI badge](https://github.com/asoffer/Icarus/workflows/CI/badge.svg)
+
+
 Compiling from source requires one of the following compilers:
 
 * g++ version >= 8.3.0


### PR DESCRIPTION
This sets up bazel, checks out the repo, then attempts to build all targets and run all tests.