### PR TITLE
Fix a debug assert

### DIFF
--- a/ir/value/module_id.h
+++ b/ir/value/module_id.h
@@ -41,7 +41,7 @@ struct ModuleId {
       inserted = true;
       handle->modules.push_back(std::make_unique<ModuleType>());
     }
-    ASSERT(id + 1 == handle->modules.size());
+    ASSERT(id < handle->modules.size());
     return std::tuple(ModuleId(id), handle->modules.back().get(), inserted);
   }
 


### PR DESCRIPTION
When a module is imported more than once, it may not have an ID at the end of the modules list.