### PR TITLE
Append a reason to MissingModule error messages.

### DIFF
--- a/compiler/dump_cfg.cc
+++ b/compiler/dump_cfg.cc
@@ -1,4 +1,5 @@
 #include <dlfcn.h>
+
 #include <iostream>
 #include <memory>
 #include <vector>
@@ -108,6 +109,7 @@ int DumpControlFlowGraph(frontend::FileName const &file_name,
     diag.Consume(frontend::MissingModule{
         .source    = canonical_file_name,
         .requestor = "",
+        .reason    = stringify(maybe_file_src),
     });
     return 1;
   }

--- a/compiler/interpretter.cc
+++ b/compiler/interpretter.cc
@@ -1,4 +1,5 @@
 #include <dlfcn.h>
+
 #include <memory>
 #include <vector>
 
@@ -37,7 +38,8 @@ int Interpret(frontend::FileName const &file_name) {
   auto maybe_file_src      = frontend::FileSource::Make(canonical_file_name);
   if (not maybe_file_src) {
     diag.Consume(frontend::MissingModule{.source    = canonical_file_name,
-                                         .requestor = ""});
+                                         .requestor = "",
+                                         .reason = stringify(maybe_file_src)});
     return 1;
   }
 

--- a/compiler/main.cc
+++ b/compiler/main.cc
@@ -130,8 +130,11 @@ int Compile(frontend::FileName const &file_name) {
   auto canonical_file_name = frontend::CanonicalFileName::Make(file_name);
   auto maybe_file_src      = frontend::FileSource::Make(canonical_file_name);
   if (not maybe_file_src) {
-    diag.Consume(frontend::MissingModule{.source    = canonical_file_name,
-                                         .requestor = ""});
+    diag.Consume(frontend::MissingModule{
+        .source    = canonical_file_name,
+        .requestor = "",
+        .reason    = stringify(maybe_file_src),
+    });
     return 1;
   }
 

--- a/frontend/source/file.cc
+++ b/frontend/source/file.cc
@@ -1,5 +1,8 @@
 #include "frontend/source/file.h"
 
+#include <cerrno>
+#include <cstring>
+
 #include "absl/strings/str_format.h"
 
 namespace frontend {
@@ -7,8 +10,9 @@ namespace frontend {
 base::expected<FileSource> FileSource::Make(CanonicalFileName file_name) {
   auto f = file_name.OpenReadOnly();
   if (not f) {
-    return base::unexpected(
-        absl::StrFormat(R"(Unable to open file "%s")", file_name.name()));
+    return base::unexpected(absl::StrFormat(R"(Failed to open file "%s": %s)",
+                                            file_name.name(),
+                                            std::strerror(errno)));
   }
   return FileSource(std::move(file_name), std::move(f));
 }

--- a/frontend/source/file.h
+++ b/frontend/source/file.h
@@ -19,13 +19,16 @@ struct MissingModule {
 
   diagnostic::DiagnosticMessage ToMessage(frontend::Source const *src) const {
     return diagnostic::DiagnosticMessage(diagnostic::Text(
-        "Could not find module named \"%s\" requested from %s", source.name(),
+        "Could not find module named \"%s\" requested from %s:\n%s",
+        source.name(),
         requestor.empty() ? "command line"
-                          : absl::StrCat("\"", requestor, "\".")));
+                          : absl::StrCat("\"", requestor, "\""),
+        reason));
   }
 
   CanonicalFileName source;
   std::string requestor;
+  std::string reason;
 };
 
 struct FileSource : public Source {

--- a/init/cli.h
+++ b/init/cli.h
@@ -24,7 +24,7 @@ extern absl::flat_hash_map<std::string, ::cli::internal::Handler *>
 
 struct Handler {
   template <typename... Args>
-  Handler(Args &&... args) : call_once_(true) {
+  Handler(Args &&...args) : call_once_(true) {
     (all_handlers.emplace(std::forward<Args>(args), this), ...);
   }
 
@@ -71,7 +71,7 @@ struct Handler {
         if (call_once_ and called_already) {
           return ::cli::internal::Result::AlreadyCalled;
         }
-
+        if (cstr == nullptr) { return ::cli::internal::Result::ParseError; }
         f(cstr);
         return ::cli::internal::Result::Ok;
       };
@@ -99,14 +99,14 @@ struct Handler {
 
 struct Flag : public Handler {
   template <typename... Args>
-  Flag(Args &&... args) : Handler(std::forward<Args>(args)...) {}
+  Flag(Args &&...args) : Handler(std::forward<Args>(args)...) {}
 
   bool called_ = false;
 };
 }  // namespace internal
 
 template <typename... Args>
-::cli::internal::Handler &Flag(Args &&... args) {
+::cli::internal::Handler &Flag(Args &&...args) {
   return *::cli::internal::owned_handlers.emplace_back(
       std::make_unique<::cli::internal::Handler>(std::forward<Args>(args)...));
 }

--- a/module/importer.h
+++ b/module/importer.h
@@ -37,6 +37,7 @@ struct FileImporter : Importer {
       diag.Consume(frontend::MissingModule{
           .source    = id.template filename<ModuleType>(),
           .requestor = "",
+          .reason    = stringify(maybe_file_src),
       });
       return ir::ModuleId::Invalid();
     }


### PR DESCRIPTION
This makes it easier to diagnose why a particular module wasn't loaded.

Also: Avoid segfaults when string flags have no value. This was supposed to be a separate commit (including only the changes to `init/cli.h`) but my git-fu is weak these days.