### PR TITLE
WIP: Improve module import ergonomics

### DIFF
--- a/compiler/BUILD
+++ b/compiler/BUILD
@@ -39,9 +39,20 @@ cc_library(
 )
 
 cc_library(
+    name = "resources",
+    hdrs = ["resources.h"],
+    deps = [
+        ":context",
+        "//diagnostic/consumer",
+        "//module:importer",
+    ],
+)
+
+cc_library(
     name = "transient_state",
     hdrs = ["transient_state.h"],
     deps = [
+        ":resources",
         "//ast",
         "//ir/blocks:basic",
         "//ir/instruction:core",
@@ -93,6 +104,7 @@ cc_library(
         ":executable_module",
         ":library_module",
         ":module",
+        ":resources",
         "//ast:ast",
         "//ast:overload_set",
         "//ast:visitor",
@@ -187,6 +199,7 @@ cc_library(
     srcs = ["compiler.cc"],
     deps = [
         ":compiler_header",
+        ":resources",
         ":verify_type",
         ":visitors",
         "//base:defer",

--- a/compiler/compiler.cc
+++ b/compiler/compiler.cc
@@ -18,12 +18,7 @@
 namespace compiler {
 
 WorkItem::Result WorkItem::Process() const {
-  module::FileImporter<LibraryModule> importer;
-  Compiler c({
-      .data                = context,
-      .diagnostic_consumer = consumer,
-      .importer            = importer,
-  });
+  Compiler c(resources);
   switch (kind) {
     case Kind::VerifyEnumBody:
       return c.VerifyBody(&node->as<ast::EnumLiteral>());

--- a/compiler/cyclic_dependency_tracker_test.cc
+++ b/compiler/cyclic_dependency_tracker_test.cc
@@ -17,7 +17,8 @@ using ::testing::Pair;
 struct TestModule : CompiledModule {
   ~TestModule() override { CompilationComplete(); }
   void ProcessNodes(base::PtrSpan<ast::Node const>,
-                    diagnostic::DiagnosticConsumer&) override {}
+                    diagnostic::DiagnosticConsumer&,
+                    module::Importer&) override {}
 };
 
 TEST(CyclicDependencyTracker, NoErrors) {

--- a/compiler/dump_cfg.cc
+++ b/compiler/dump_cfg.cc
@@ -125,8 +125,9 @@ int DumpControlFlowGraph(frontend::FileName const &file_name,
 
   auto *src = &*maybe_file_src;
   diag      = diagnostic::StreamingConsumer(stderr, src);
+  module::FileImporter<LibraryModule> importer;
   compiler::ExecutableModule exec_mod;
-  exec_mod.AppendNodes(frontend::Parse(*src, diag), diag);
+  exec_mod.AppendNodes(frontend::Parse(*src, diag), diag, importer);
   if (diag.num_consumed() != 0) { return 1; }
   auto &main_fn = exec_mod.main();
 

--- a/compiler/emit/BUILD
+++ b/compiler/emit/BUILD
@@ -104,6 +104,7 @@ cc_library(
     deps = [
         "//ast",
         "//compiler:compiler_header",
+        "//compiler:resources",
         "//compiler/emit:common",
         "//ir/value",
     ],

--- a/compiler/emit/call.cc
+++ b/compiler/emit/call.cc
@@ -1,6 +1,7 @@
 #include "ast/ast.h"
 #include "base/meta.h"
 #include "compiler/compiler.h"
+#include "compiler/resources.h"
 
 namespace compiler {
 namespace {
@@ -93,7 +94,7 @@ void EmitCall(Tag, Compiler &compiler, ast::Expression const *callee,
   auto [callee_fn, overload_type, context] =
       EmitCallee(compiler, callee, callee_qual_type, args);
 
-  Compiler c = compiler.MakeChild(Compiler::PersistentResources{
+  Compiler c = compiler.MakeChild(PersistentResources{
       .data                = context ? *context : compiler.context(),
       .diagnostic_consumer = compiler.diag(),
       .importer            = compiler.importer(),
@@ -303,7 +304,6 @@ void Compiler::EmitAssign(
     EmitCopyAssign(to[0], type::Typed<ir::Value>(
                               result, context().qual_type(node)->type()));
   }
-
 
   auto args = node->args().Transform([this](ast::Expression const *expr) {
     return type::Typed<ir::Value>(EmitValue(expr),

--- a/compiler/executable_module.h
+++ b/compiler/executable_module.h
@@ -20,8 +20,8 @@ struct ExecutableModule : CompiledModule {
 
  protected:
   void ProcessNodes(base::PtrSpan<ast::Node const> nodes,
-                    diagnostic::DiagnosticConsumer &diag) override {
-    module::FileImporter<LibraryModule> importer;
+                    diagnostic::DiagnosticConsumer &diag,
+                    module::Importer &importer) override {
     Compiler c({
         .data                = context(),
         .diagnostic_consumer = diag,

--- a/compiler/interpretter.cc
+++ b/compiler/interpretter.cc
@@ -58,8 +58,9 @@ int Interpret(frontend::FileName const &file_name) {
 
   auto *src = &*maybe_file_src;
   diag      = diagnostic::StreamingConsumer(stderr, src);
+  module::FileImporter<LibraryModule> importer;
   compiler::ExecutableModule exec_mod;
-  exec_mod.AppendNodes(frontend::Parse(*src, diag), diag);
+  exec_mod.AppendNodes(frontend::Parse(*src, diag), diag, importer);
   if (diag.num_consumed() != 0) { return 1; }
   auto &main_fn = exec_mod.main();
 

--- a/compiler/library_module.h
+++ b/compiler/library_module.h
@@ -16,10 +16,10 @@ struct LibraryModule : CompiledModule {
 
  protected:
   void ProcessNodes(base::PtrSpan<ast::Node const> nodes,
-                    diagnostic::DiagnosticConsumer &diag) override {
+                    diagnostic::DiagnosticConsumer &diag,
+                    module::Importer &importer) override {
     ExportsComplete();
 
-    module::FileImporter<LibraryModule> importer;
     Compiler c({
         .data                = context(),
         .diagnostic_consumer = diag,

--- a/compiler/main.cc
+++ b/compiler/main.cc
@@ -159,8 +159,9 @@ int Compile(frontend::FileName const &file_name) {
 
   auto *src = &*maybe_file_src;
   diag      = diagnostic::StreamingConsumer(stderr, src);
+  module::FileImporter<LibraryModule> importer;
   compiler::ExecutableModule exec_mod;
-  exec_mod.AppendNodes(frontend::Parse(*src, diag), diag);
+  exec_mod.AppendNodes(frontend::Parse(*src, diag), diag, importer);
   if (diag.num_consumed() != 0) { return 1; }
 
   return CompileToObjectFile(exec_mod, target_machine);

--- a/compiler/main.cc
+++ b/compiler/main.cc
@@ -1,7 +1,9 @@
+#include <cstdlib>
 #include <string>
 #include <string_view>
 #include <system_error>
 #include <utility>
+#include <vector>
 
 #include "absl/debugging/failure_signal_handler.h"
 #include "absl/debugging/symbolize.h"
@@ -9,6 +11,7 @@
 #include "absl/flags/parse.h"
 #include "absl/flags/usage.h"
 #include "absl/flags/usage_config.h"
+#include "absl/strings/match.h"
 #include "absl/strings/str_split.h"
 #include "backend/function.h"
 #include "backend/type.h"
@@ -48,6 +51,9 @@ ABSL_FLAG(std::string, link, "",
 ABSL_FLAG(bool, debug_parser, false,
           "Step through the parser step-by-step for debugging.");
 ABSL_FLAG(bool, opt_ir, false, "Optimize intermediate representation.");
+ABSL_FLAG(std::vector<std::string>, module_paths, {},
+          "Comma-separated list of paths to search when importing modules. "
+          "Defaults to $ICARUS_MODULE_PATH.");
 
 namespace debug {
 extern bool parser;
@@ -175,6 +181,10 @@ bool HelpFilter(absl::string_view module) {
 }
 
 int main(int argc, char *argv[]) {
+  // Provide a new default for --module_paths.
+  if (char *const env_str = std::getenv("ICARUS_MODULE_PATH")) {
+    absl::SetFlag(&FLAGS_module_paths, absl::StrSplit(env_str, ':'));
+  }
   absl::FlagsUsageConfig flag_config;
   flag_config.contains_helpshort_flags = &HelpFilter;
   flag_config.contains_help_flags      = &HelpFilter;

--- a/compiler/resources.h
+++ b/compiler/resources.h
@@ -1,0 +1,20 @@
+#ifndef ICARUS_COMPILER_RESOURCES_H
+#define ICARUS_COMPILER_RESOURCES_H
+
+#include "compiler/context.h"
+#include "module/importer.h"
+#include "diagnostic/consumer/consumer.h"
+
+namespace compiler {
+
+// Resources and pointers/references to data that are guaranteed to outlive
+// any Compiler construction.
+struct PersistentResources {
+  Context &data;
+  diagnostic::DiagnosticConsumer &diagnostic_consumer;
+  module::Importer &importer;
+};
+
+}
+
+#endif  // ICARUS_COMPILER_RESOURCES_H

--- a/compiler/transient_state.h
+++ b/compiler/transient_state.h
@@ -7,6 +7,7 @@
 
 #include "absl/types/span.h"
 #include "ast/ast.h"
+#include "compiler/resources.h"
 #include "ir/blocks/basic.h"
 #include "ir/instruction/core.h"
 #include "ir/value/label.h"
@@ -26,9 +27,7 @@ struct WorkItem {
 
   Kind kind;
   ast::Node const *node;
-  // TODO: Should we just store PersistentResources directly?
-  Context &context;
-  diagnostic::DiagnosticConsumer &consumer;
+  PersistentResources &resources;
 };
 
 struct WorkQueue {

--- a/compiler/verify/BUILD
+++ b/compiler/verify/BUILD
@@ -325,6 +325,7 @@ cc_library(
     deps = [
         "//ast",
         "//compiler:compiler_header",
+        "//compiler:resources",
         "//compiler/verify:common",
         "//type:cast",
         "//type:qual_type",
@@ -495,6 +496,7 @@ cc_library(
         "//ast",
         "//compiler:compiler_header",
         "//compiler:library_module",
+        "//compiler:resources",
         "//compiler/emit:common",
         "//type:qual_type",
         "//type:typed_value",
@@ -535,6 +537,7 @@ cc_library(
         ":common",
         "//ast",
         "//compiler:compiler_header",
+        "//compiler:resources",
         "//type:qual_type",
     ],
 )

--- a/compiler/verify/enum_literal.cc
+++ b/compiler/verify/enum_literal.cc
@@ -54,10 +54,9 @@ WorkItem::Result Compiler::VerifyBody(ast::EnumLiteral const *node) {
 type::QualType Compiler::VerifyType(ast::EnumLiteral const *node) {
   LOG("compile-work-queue", "Request work enum: %p", node);
   state_.work_queue.Enqueue({
-      .kind     = WorkItem::Kind::VerifyEnumBody,
-      .node     = node,
-      .context  = context(),
-      .consumer = diag(),
+      .kind      = WorkItem::Kind::VerifyEnumBody,
+      .node      = node,
+      .resources = resources_,
   });
   return context().set_qual_type(node, type::QualType::Constant(type::Type_));
 }

--- a/compiler/verify/import.cc
+++ b/compiler/verify/import.cc
@@ -67,9 +67,7 @@ type::QualType Compiler::VerifyType(ast::Import const *node) {
     return context().set_qual_type(node, qt);
   }
 
-  auto canonical_file_name =
-      frontend::CanonicalFileName::Make(frontend::FileName(maybe_src->get()));
-  ir::ModuleId mod_id = importer().Import(canonical_file_name);
+  ir::ModuleId mod_id = importer().Import(maybe_src->get());
   if (mod_id == ir::ModuleId::Invalid()) {
     qt.MarkError();
   } else {

--- a/compiler/verify/import_test.cc
+++ b/compiler/verify/import_test.cc
@@ -50,10 +50,9 @@ TEST(Import, NonConstantAndInvalidType) {
 }
 
 TEST(Import, ByteViewLiteral) {
+  constexpr std::string_view kModule = "some-module";
   test::TestModule mod;
-  EXPECT_CALL(mod.importer, Import(frontend::CanonicalFileName::Make(
-                                frontend::FileName("some-module"))))
-      .WillOnce(Return(ir::ModuleId(7)));
+  EXPECT_CALL(mod.importer, Import(kModule)).WillOnce(Return(ir::ModuleId(7)));
   auto const *import = mod.Append<ast::Expression>(R"(import "some-module")");
   auto const *qt     = mod.context().qual_type(import);
   ASSERT_NE(qt, nullptr);
@@ -62,10 +61,9 @@ TEST(Import, ByteViewLiteral) {
 }
 
 TEST(Import, ConstantByteView) {
+  constexpr std::string_view kModule = "some-module";
   test::TestModule mod;
-  EXPECT_CALL(mod.importer, Import(frontend::CanonicalFileName::Make(
-                                frontend::FileName("some-module"))))
-      .WillOnce(Return(ir::ModuleId(7)));
+  EXPECT_CALL(mod.importer, Import(kModule)).WillOnce(Return(ir::ModuleId(7)));
   mod.AppendCode(R"(str ::= "some-module")");
   auto const *import = mod.Append<ast::Expression>(R"(import str)");
   auto const *qt     = mod.context().qual_type(import);

--- a/compiler/verify/parameterized_struct_literal.cc
+++ b/compiler/verify/parameterized_struct_literal.cc
@@ -2,6 +2,7 @@
 #include "compiler/compiler.h"
 #include "compiler/emit/common.h"
 #include "compiler/library_module.h"
+#include "compiler/resources.h"
 #include "compiler/verify/common.h"
 #include "type/generic_struct.h"
 #include "type/qual_type.h"
@@ -27,12 +28,11 @@ type::QualType Compiler::VerifyType(
 
     if (inserted) {
       LOG("ParameterizedStructLiteral", "inserted! %s", node->DebugString());
-      auto compiler =
-          instantiation_compiler.MakeChild(Compiler::PersistentResources{
-              .data                = context,
-              .diagnostic_consumer = instantiation_compiler.diag(),
-              .importer            = instantiation_compiler.importer(),
-          });
+      auto compiler = instantiation_compiler.MakeChild(PersistentResources{
+          .data                = context,
+          .diagnostic_consumer = instantiation_compiler.diag(),
+          .importer            = instantiation_compiler.importer(),
+      });
       compiler.builder().CurrentGroup() = cg;
 
       type::Struct *s = type::Allocate<type::Struct>(

--- a/compiler/verify/short_function_literal.cc
+++ b/compiler/verify/short_function_literal.cc
@@ -1,5 +1,6 @@
 #include "ast/ast.h"
 #include "compiler/compiler.h"
+#include "compiler/resources.h"
 #include "compiler/verify/common.h"
 
 namespace compiler {
@@ -26,12 +27,11 @@ type::QualType VerifyGeneric(Compiler &c,
 
     if (inserted) {
       LOG("FunctionLiteral", "inserted! %s", node->DebugString());
-      auto compiler =
-          instantiation_compiler.MakeChild(Compiler::PersistentResources{
-              .data                = context,
-              .diagnostic_consumer = instantiation_compiler.diag(),
-              .importer            = instantiation_compiler.importer(),
-          });
+      auto compiler = instantiation_compiler.MakeChild(PersistentResources{
+          .data                = context,
+          .diagnostic_consumer = instantiation_compiler.diag(),
+          .importer            = instantiation_compiler.importer(),
+      });
       compiler.builder().CurrentGroup() = cg;
       auto qt                           = VerifyConcrete(compiler, node);
       auto outs = qt.type().as<type::Function>().output();

--- a/compiler/verify/struct_literal.cc
+++ b/compiler/verify/struct_literal.cc
@@ -29,10 +29,9 @@ WorkItem::Result Compiler::VerifyBody(ast::StructLiteral const *node) {
 type::QualType Compiler::VerifyType(ast::StructLiteral const *node) {
   LOG("StructLiteral", "Verify type %p %s", node, node->DebugString());
   state_.work_queue.Enqueue({
-      .kind     = WorkItem::Kind::VerifyStructBody,
-      .node     = node,
-      .context  = context(),
-      .consumer = diag(),
+      .kind      = WorkItem::Kind::VerifyStructBody,
+      .node      = node,
+      .resources = resources(),
   });
   return context().set_qual_type(node, type::QualType::Constant(type::Type_));
 }

--- a/module/BUILD
+++ b/module/BUILD
@@ -31,6 +31,7 @@ cc_library(
 cc_library(
     name = "importer",
     hdrs = ["importer.h"],
+    srcs = ["importer.cc"],
     deps = [
         ":module",
         "//frontend/source:file_name",

--- a/module/BUILD
+++ b/module/BUILD
@@ -36,6 +36,7 @@ cc_library(
         ":module",
         "//frontend/source:file_name",
         "//ir/value:module_id",
+        "@com_google_absl//absl/strings",
     ],
 )
 

--- a/module/importer.cc
+++ b/module/importer.cc
@@ -1,0 +1,40 @@
+#include "module/importer.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <string_view>
+
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_split.h"
+#include "frontend/source/file_name.h"
+
+namespace module {
+namespace {
+
+bool FileExists(std::string const& path) {
+  if (std::FILE* f = std::fopen(path.c_str(), "r")) {
+    std::fclose(f);
+    return true;
+  }
+  return false;
+}
+
+}  // namespace
+
+frontend::CanonicalFileName ResolveModulePath(
+    frontend::CanonicalFileName const& module_path) {
+  // Respect absolute paths.
+  if (absl::StartsWith(module_path.name(), "/")) { return module_path; }
+  // Walk the entries in $ICARUS_MODULE_PATH to find a valid source file.
+  if (char* const lookup_paths = std::getenv("ICARUS_MODULE_PATH")) {
+    for (std::string_view base_path : absl::StrSplit(lookup_paths, ':')) {
+      std::string path = absl::StrCat(base_path, "/", module_path.name());
+      if (FileExists(path)) {
+        return frontend::CanonicalFileName::Make(frontend::FileName(path));
+      }
+    }
+  }
+  // Fall back to using the given path as-is, relative to $PWD.
+  return module_path;
+}
+}  // namespace module

--- a/module/importer.h
+++ b/module/importer.h
@@ -35,9 +35,9 @@ struct FileImporter : Importer {
     if (auto maybe_file_src =
             frontend::FileSource::Make(ResolveModulePath(module_path))) {
       std::thread t(
-          [mod = mod, file_src = std::move(*maybe_file_src)]() mutable {
+          [this, mod = mod, file_src = std::move(*maybe_file_src)]() mutable {
             diagnostic::StreamingConsumer diag(stderr, &file_src);
-            mod->AppendNodes(frontend::Parse(file_src, diag), diag);
+            mod->AppendNodes(frontend::Parse(file_src, diag), diag, *this);
           });
       t.detach();
       return id;

--- a/module/importer.h
+++ b/module/importer.h
@@ -1,6 +1,7 @@
 #ifndef ICARUS_MODULE_IMPORTER_H
 #define ICARUS_MODULE_IMPORTER_H
 
+#include <string_view>
 #include <thread>
 
 #include "diagnostic/consumer/streaming.h"

--- a/module/importer.h
+++ b/module/importer.h
@@ -14,12 +14,14 @@ namespace module {
 // `Importer` is responsible for scheduling any imports requested from an
 // `import` expression.
 struct Importer {
-  virtual ir::ModuleId Import(frontend::CanonicalFileName const& filename) = 0;
+  virtual ir::ModuleId Import(std::string_view module_locator) = 0;
 };
 
 template <typename ModuleType>
 struct FileImporter : Importer {
-  ir::ModuleId Import(frontend::CanonicalFileName const& file_name) override {
+  ir::ModuleId Import(std::string_view module_locator) override {
+    auto file_name = frontend::CanonicalFileName::Make(
+        frontend::FileName(std::string(module_locator)));
     auto [id, mod, inserted] = ir::ModuleId::FromFile<ModuleType>(file_name);
     if (not inserted) { return id; }
 

--- a/module/mock_importer.h
+++ b/module/mock_importer.h
@@ -1,7 +1,8 @@
 #ifndef ICARUS_MODULE_MOCK_IMPORTER_H
 #define ICARUS_MODULE_MOCK_IMPORTER_H
 
-#include "frontend/source/file_name.h"
+#include <string_view>
+
 #include "gmock/gmock.h"
 #include "ir/value/module_id.h"
 #include "module/importer.h"
@@ -9,8 +10,8 @@
 namespace module {
 
 struct MockImporter : Importer {
-  MOCK_METHOD(ir::ModuleId, Import,
-              (frontend::CanonicalFileName const& filename), (override));
+  MOCK_METHOD(ir::ModuleId, Import, (std::string_view module_locator),
+              (override));
 };
 
 }  // namespace module

--- a/module/module.cc
+++ b/module/module.cc
@@ -26,17 +26,19 @@ void BasicModule::InitializeNodes(base::PtrSpan<ast::Node> nodes) {
 void BasicModule::ExportsComplete() { exports_complete_.Notify(); }
 
 void BasicModule::AppendNode(std::unique_ptr<ast::Node> node,
-                             diagnostic::DiagnosticConsumer &diag) {
+                             diagnostic::DiagnosticConsumer &diag,
+                             Importer &importer) {
   InitializeNodes(base::PtrSpan<ast::Node>(&node, 1));
-  ProcessNodes(base::PtrSpan<ast::Node const>(&node, 1), diag);
+  ProcessNodes(base::PtrSpan<ast::Node const>(&node, 1), diag, importer);
   nodes_.push_back(std::move(node));
 }
 
 // TODO not sure this is necessary.
 void BasicModule::AppendNodes(std::vector<std::unique_ptr<ast::Node>> nodes,
-                              diagnostic::DiagnosticConsumer &diag) {
+                              diagnostic::DiagnosticConsumer &diag,
+                              Importer &importer) {
   InitializeNodes(nodes);
-  ProcessNodes(nodes, diag);
+  ProcessNodes(nodes, diag, importer);
   nodes_.insert(nodes_.end(), std::make_move_iterator(nodes.begin()),
                 std::make_move_iterator(nodes.end()));
 }

--- a/module/module.h
+++ b/module/module.h
@@ -29,6 +29,7 @@ template <typename T>
 struct ExtendedModule;
 
 // Forward-declare to break the dependency cycle.
+// TODO: Fix this!
 struct Importer;
 
 // BasicModule:

--- a/module/module.h
+++ b/module/module.h
@@ -28,6 +28,9 @@ namespace module {
 template <typename T>
 struct ExtendedModule;
 
+// Forward-declare to break the dependency cycle.
+struct Importer;
+
 // BasicModule:
 //
 // Represents a unit of compilation, beyond which all intercommunication must be
@@ -48,9 +51,9 @@ struct BasicModule : base::Cast<BasicModule> {
   BasicModule &operator=(BasicModule const &) = delete;
 
   void AppendNode(std::unique_ptr<ast::Node> node,
-                  diagnostic::DiagnosticConsumer &diag);
+                  diagnostic::DiagnosticConsumer &diag, Importer &importer);
   void AppendNodes(std::vector<std::unique_ptr<ast::Node>> nodes,
-                   diagnostic::DiagnosticConsumer &diag);
+                   diagnostic::DiagnosticConsumer &diag, Importer &importer);
 
   absl::Span<ast::Declaration const *const> ExportedDeclarations(
       std::string_view name) const;
@@ -59,7 +62,7 @@ struct BasicModule : base::Cast<BasicModule> {
 
  protected:
   virtual void ProcessNodes(base::PtrSpan<ast::Node const>,
-                            diagnostic::DiagnosticConsumer &) = 0;
+                            diagnostic::DiagnosticConsumer &, Importer &) = 0;
 
   // Child classes must call this when they no longer append nodes to the syntax
   // tree. This notifies users of the module that it is safe to consume the

--- a/repl/main.cc
+++ b/repl/main.cc
@@ -1,6 +1,9 @@
 #include <dlfcn.h>
 
+#include <cstdlib>
 #include <memory>
+#include <string>
+#include <string_view>
 #include <vector>
 
 #include "absl/debugging/failure_signal_handler.h"
@@ -11,7 +14,6 @@
 #include "absl/flags/usage_config.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_split.h"
-#include "absl/strings/string_view.h"
 #include "base/log.h"
 #include "diagnostic/consumer/streaming.h"
 #include "repl/module.h"
@@ -22,12 +24,19 @@ ABSL_FLAG(std::vector<std::string>, log, {},
 ABSL_FLAG(std::string, link, "",
           "Library to be dynamically loaded by the compiler to be used "
           "at compile-time. Libraries will not be unloaded.");
+ABSL_FLAG(std::vector<std::string>, module_paths, {},
+          "Comma-separated list of paths to search when importing modules. "
+          "Defaults to $ICARUS_MODULE_PATH.");
 
-bool HelpFilter(absl::string_view module) {
+bool HelpFilter(std::string_view module) {
   return absl::EndsWith(module, "/main.cc");
 }
 
 int main(int argc, char *argv[]) {
+  // Provide a new default for --module_paths.
+  if (char *const env_str = std::getenv("ICARUS_MODULE_PATH")) {
+    absl::SetFlag(&FLAGS_module_paths, absl::StrSplit(env_str, ':'));
+  }
   absl::FlagsUsageConfig flag_config;
   flag_config.contains_helpshort_flags = &HelpFilter;
   flag_config.contains_help_flags      = &HelpFilter;
@@ -39,7 +48,7 @@ int main(int argc, char *argv[]) {
   absl::InstallFailureSignalHandler(opts);
 
   std::vector<std::string> log_keys = absl::GetFlag(FLAGS_log);
-  for (absl::string_view key : log_keys) { base::EnableLogging(key); }
+  for (std::string_view key : log_keys) { base::EnableLogging(key); }
 
   if (std::string lib = absl::GetFlag(FLAGS_link); not lib.empty()) {
     ASSERT_NOT_NULL(dlopen(lib.c_str(), RTLD_LAZY));
@@ -53,7 +62,7 @@ int main(int argc, char *argv[]) {
   repl::Source source(&std::cin, &std::cout);
   diagnostic::StreamingConsumer diag(stderr, &source);
 
-  module::FileImporter<LibraryModule> importer;
+  module::FileImporter<compiler::LibraryModule> importer;
   repl::Module mod;
   // TODO: Handle parse failures
   while (true) {

--- a/repl/main.cc
+++ b/repl/main.cc
@@ -53,8 +53,11 @@ int main(int argc, char *argv[]) {
   repl::Source source(&std::cin, &std::cout);
   diagnostic::StreamingConsumer diag(stderr, &source);
 
+  module::FileImporter<LibraryModule> importer;
   repl::Module mod;
   // TODO: Handle parse failures
-  while (true) { mod.AppendNodes(frontend::Parse(source, diag), diag); }
+  while (true) {
+    mod.AppendNodes(frontend::Parse(source, diag), diag, importer);
+  }
   return 0;
 }

--- a/repl/module.cc
+++ b/repl/module.cc
@@ -1,4 +1,5 @@
 #include "repl/module.h"
+
 #include "absl/strings/str_format.h"
 #include "ast/ast.h"
 #include "ast/expression.h"
@@ -32,7 +33,8 @@ void ReplEval(ast::Expression const *expr, compiler::Compiler *compiler) {
 }  // namespace
 
 void Module::ProcessNodes(base::PtrSpan<ast::Node const> nodes,
-                          diagnostic::DiagnosticConsumer &diag) {
+                          diagnostic::DiagnosticConsumer &diag,
+                          module::Importer &importer) {
   compiler::Compiler c({
       .data                = context(),
       .diagnostic_consumer = diag,

--- a/repl/module.h
+++ b/repl/module.h
@@ -12,9 +12,8 @@ struct Module : compiler::CompiledModule {
   ~Module() override {}
 
   void ProcessNodes(base::PtrSpan<ast::Node const> nodes,
-                    diagnostic::DiagnosticConsumer &diag) override;
-
-  module::FileImporter<compiler::LibraryModule> importer;
+                    diagnostic::DiagnosticConsumer &diag,
+                    module::Importer &importer) override;
 };
 
 }  // namespace repl

--- a/test/module.h
+++ b/test/module.h
@@ -32,7 +32,8 @@ struct TestModule : compiler::CompiledModule {
   void AppendCode(std::string code) {
     code.push_back('\n');
     frontend::StringSource source(std::move(code));
-    AppendNodes(frontend::Parse(source, consumer, next_line_num), consumer);
+    AppendNodes(frontend::Parse(source, consumer, next_line_num), consumer,
+                importer);
     next_line_num += 100;
   }
 
@@ -41,7 +42,7 @@ struct TestModule : compiler::CompiledModule {
     auto node       = test::ParseAs<NodeType>(std::move(code), next_line_num);
     auto const* ptr = ASSERT_NOT_NULL(node.get());
     next_line_num += 100;
-    AppendNode(std::move(node), consumer);
+    AppendNode(std::move(node), consumer, importer);
     return ptr;
   }
 
@@ -51,7 +52,8 @@ struct TestModule : compiler::CompiledModule {
 
  protected:
   void ProcessNodes(base::PtrSpan<ast::Node const> nodes,
-                    diagnostic::DiagnosticConsumer& diag) override {
+                    diagnostic::DiagnosticConsumer& diag,
+                    module::Importer&) override {
     compiler.VerifyAll(nodes);
     compiler.CompleteDeferredBodies();
   }

--- a/test/module.h
+++ b/test/module.h
@@ -68,7 +68,7 @@ ast::Call const* MakeCall(
       frontend::SourceRange{}, ParseAs<ast::Expression>(std::move(fn)),
       MakeArguments(std::move(pos_args), std::move(named_args)));
   auto* expr = call_expr.get();
-  module->AppendNode(std::move(call_expr), module->consumer);
+  module->AppendNode(std::move(call_expr), module->consumer, module->importer);
   return expr;
 }
 


### PR DESCRIPTION
I believe the plan is to support multiple types of importers, so I've started by making the generic Importer interface more agnostic to the type of module locator it accepts. For FileImporter, this should be a (relative) path to an Icarus file.

My main goal here is to make relative imports work.