### PR TITLE
Unbreak diagnostic printing from SharedSourceType

### DIFF
--- a/diagnostic/console_renderer.cc
+++ b/diagnostic/console_renderer.cc
@@ -125,8 +125,12 @@ void ConsoleRenderer::WriteSourceQuote(frontend::SourceBuffer const &buffer,
 void ConsoleRenderer::Add(frontend::Source const *source, Category cat,
                           DiagnosticMessage const &diag) {
   has_data_ = true;
-  absl::FPrintF(out_, "\033[31;1mError\033[0m in \033[1m%s\033[0m:\n",
-                source->FileName());
+  if (std::string filename = source->FileName(); !filename.empty()) {
+    absl::FPrintF(out_, "\033[31;1mError\033[0m in \033[1m%s\033[0m:\n",
+                  filename);
+  } else {
+    std::fputs("\033[31;1mError\033[0m:\n", out_);
+  }
   diag.for_each_component([&](auto const &component) {
     constexpr auto type = base::meta<std::decay_t<decltype(component)>>;
     if constexpr (type == base::meta<Text>) {

--- a/frontend/source/shared.cc
+++ b/frontend/source/shared.cc
@@ -7,7 +7,7 @@ namespace {
 struct SharedSourceType : Source {
   SourceChunk ReadUntil(char delim) override { UNREACHABLE(); }
   std::string_view line(LineNum line_num) const override { UNREACHABLE(); }
-  std::string FileName() const override { UNREACHABLE(); }
+  std::string FileName() const override { return ""; }
   SourceBuffer& buffer() override { UNREACHABLE(); }
   SourceBuffer const& buffer() const override { UNREACHABLE(); }
 };


### PR DESCRIPTION
This was broken by the changes related to gh-33, which included an unconditional call to `FileName()` despite the shared source not having an implementation of that method.

Checking if the file name is empty is certainly a hack, but then again, so is passing around a Source that explodes if you call any of its methods.