### PR TITLE
Misc. stdlib improvements

### DIFF
--- a/examples/file.ic
+++ b/examples/file.ic
@@ -1,18 +1,19 @@
 --     ::= import "core.ic"
-str    ::= import "string.ic"
 cstdio ::= import "cstdio.ic"
 errno  ::= import "errno.ic"
 file   ::= import "file.ic"
 io     ::= import "io.ic"
 
-// File is a user-defined scope in the file module. Given a file name it attempts
-// to open the file, creating a handle (a C++ FILE*) if it can open the file, or
-// goes to the error block with the value assigned into errno. If it was
-// successful, the open block is executed and then the file is closed.
+// `With` is a user-defined scope in the `file` module.
+// It attempts to open the given filepath, creating a handle (a C++ FILE*) if
+// it succeeds. Otherwise, it jumps to the error block with the value assigned
+// to errno. If it was successful, the `open` block is executed, after which
+// the file is closed.
 
 file.With("examples/file.ic") open [f: file.File] {
-  contents := f'read_to(str.string)
-  contents'Print
+  file.Lines(f) each [line: []char] {
+    io.Print(line)
+  }
 } error [e: errno.error] {
   io.Print("Error opening file: ")
   io.Print(e as u64)

--- a/stdlib/core.ic
+++ b/stdlib/core.ic
@@ -46,19 +46,16 @@ repeat ::= scope (i64) {
   exit ::= () -> () {}
 }
 
-// TODO: We shouldn't need to export any of this.
-#{export}
 range ::= struct {
-  #{export}
   current: i64
-  #{export}
   end: i64
 }
 
 #{export}
 for ::= scope (range) {
   enter ::= jump [state: *range] (begin: i64, end: i64) {
-    @state = range.{ current = begin \\ end = end }
+    state.current = begin
+    state.end = end
     goto state.current >= state.end, done(), do(state.current)
   }
 

--- a/stdlib/cstdio.ic
+++ b/stdlib/cstdio.ic
@@ -1,10 +1,15 @@
-// This module provides an ierface to functions in the <stdio.h> C-header file.
+// This module provides an interface to functions in the <stdio.h> C-header
+// file.
 
-#{export} File   ::= 'opaque
+#{export} File ::= 'opaque
+#{export} eof  ::= 4294967295 as i32
+
 #{export} fopen  ::= foreign("fopen", ([*]char, [*]char) -> *File)
 #{export} fclose ::= foreign("fclose", *File -> i32)
 #{export} fgets  ::= foreign("fgets", ([*]char, i32, *File) -> [*]char)
 #{export} fgetc  ::= foreign("fgetc", (*File) -> i32)
 #{export} fread  ::= foreign("fread", ([*]char, u64, u64, *File) -> u64)
 #{export} puts   ::= foreign("puts", [*]char -> i32)
-#{export} eof    ::= 4294967295 as i32
+
+#{export} getline  ::= foreign("getline", (*[*]char, *u64, *File) -> i64)
+#{export} getdelim ::= foreign("getdelim", (*[*]char, *u64, i32, *File) -> i64)

--- a/stdlib/file.ic
+++ b/stdlib/file.ic
@@ -1,6 +1,7 @@
 core   ::= import "core.ic"
 errno  ::= import "errno.ic"
 cstdio ::= import "cstdio.ic"
+memory ::= import "memory.ic"
 
 #{export}
 File ::= struct {
@@ -50,4 +51,41 @@ read_to ::= (f: File, T :: type) -> T {
     result'append(slice(&buffer[0], num_read))
   }
   return result
+}
+
+LinesState ::= struct {
+  handle: *cstdio.File
+  line: [*]char
+  bufsize: u64
+  line_length: i64
+
+  (destroy) ::= (self: *LinesState) -> () {
+    memory.deallocate(self.line)
+  }
+}
+
+next_line ::= (s: *LinesState) -> bool {
+  s.line_length = cstdio.getline(&s.line, &s.bufsize, s.handle)
+  return s.line_length > 0
+}
+
+as_slice ::= (s: *LinesState) -> []char {
+  return slice(s.line, s.line_length as u64)
+}
+
+#{export}
+Lines ::= scope(LinesState) {
+  enter ::= jump [state: *LinesState] (f: File) {
+    state.handle = f'CFileHandle
+    goto state'next_line(), each(state'as_slice()), done()
+  }
+
+  each ::= block {
+    before ::= (line: []char) => line
+    after ::= jump [state: *LinesState] () {
+      goto state'next_line(), each(state'as_slice()), done()
+    }
+  }
+
+  exit ::= () -> () {}
 }


### PR DESCRIPTION
The main contribution here is the `file.Lines` scope, which makes it easy to iterate over the lines of a file. I also did some cleanup of the `core.for` scope, which no longer requires exporting its state struct.

Known issues:
 - we don't appear to ever destroy the scope state object, so we never free the line buffer.
 - it would be nice to have a way to compose the `file.With` and `file.Lines` scopes, something like:

```
file.WithLines("foo.txt") each [line: []char] {
  // operate on line
} error [e: errno.error] {
  // handle file open/read errors
}
```