### PR TITLE
Update the absl dependency and use clang++-12

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,6 @@
 build --crosstool_top=//toolchain:cc
 build --cpu=clang
+build --copt=-fbracket-depth=1024
 build --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
 build --strip=never
 build --color=yes

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,9 +3,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
   name = "com_google_absl",
-  urls = ["https://github.com/abseil/abseil-cpp/archive/9c6a50fdd80bb39fabd95faeda84f04062685ff3.zip"],
-  strip_prefix = "abseil-cpp-9c6a50fdd80bb39fabd95faeda84f04062685ff3",
-  sha256 = "e839ea17b0a9c3dcdb74d091de3c3e7fb0118b837384ed472a7eb4b380fa2d1e"
+  urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20210324.2.zip"],
+  strip_prefix = "abseil-cpp-20210324.2",
+  sha256 = "1a7edda1ff56967e33bc938a4f0a68bb9efc6ba73d62bb4a5f5662463698056c",
 )
 
 http_archive(
@@ -14,3 +14,4 @@ http_archive(
   strip_prefix = "googletest-d166e09483845b9b6a658dccc3d3dbb293676b62",
   sha256 = "d27641a853c49d3e8d7b9bbced1ceb861336134cd148bf6db720a40ccde66516",
 )
+

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -54,7 +54,7 @@ cc_toolchain(
 
 cc_toolchain_config(
     name = 'clang_toolchain_config',
-    compiler_path = '/usr/bin/clang++-10',
+    compiler_path = '/usr/bin/clang++-12',
     warnings = [
         "all",
         "error",


### PR DESCRIPTION
The old version of absl had issues for my glibc, and perhaps also with clang++-13.