### PR TITLE
Pass through extra positional arguments instead of using a flag

### DIFF
--- a/compiler/BUILD
+++ b/compiler/BUILD
@@ -421,6 +421,7 @@ cc_binary(
         "@com_google_absl//absl/flags:parse",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:span",
     ],
 )
 

--- a/examples/smoke_test.sh
+++ b/examples/smoke_test.sh
@@ -9,7 +9,7 @@ root=$(dirname "$examples")
 binary="$root/bazel-bin/compiler/interpret"
 export ICARUS_MODULE_PATH="$root/stdlib"
 
-$binary "$examples/arguments.ic" --program_arguments="hello world!" >/dev/null && echo arguments OK
+$binary "$examples/arguments.ic" hello world >/dev/null && echo arguments OK
 $binary "$examples/c_file.ic" >/dev/null && echo c_file OK
 $binary "$examples/constant_scopes.ic" >/dev/null && echo constant_scopes OK
 $binary "$examples/date_time.ic" >/dev/null && echo date_time OK


### PR DESCRIPTION
This enables the use of shell globs when passing arguments to an Icarus program, and matches the convention for most interpreted languages.

Before:

```
$ icarus examples/arguments.ic --program_arguments='foo ba*'
There are 2 program Argument(s):
  foo
  ba*
```

After:

```
$ icarus examples/arguments.ic foo ba*
There are 3 program Argument(s):
  foo
  bar
  baz
```

